### PR TITLE
Add unit declarator to module declarations

### DIFF
--- a/lib/HTTP/ParseParams.pm6
+++ b/lib/HTTP/ParseParams.pm6
@@ -1,7 +1,7 @@
 use URI::Encode;
 
 #| Parses cookies, query parameters, and post data from HTTP requests.
-module HTTP::ParseParams;
+unit module HTTP::ParseParams;
 
 #| Pass in some data and a type, and get back a hash containing the passed parameters
 our sub parse(Str $data, Bool :$cookie, Bool :$urlencoded is copy, Bool :$formdata is copy, Str :$content-type --> Hash) {


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.
